### PR TITLE
add new param to highlight search endpoint

### DIFF
--- a/src/test/kotlin/com/boclips/apidocs/HestuDocTests.kt
+++ b/src/test/kotlin/com/boclips/apidocs/HestuDocTests.kt
@@ -174,7 +174,12 @@ class HestuDocTests : AbstractDocTests() {
             RequestDocumentation.parameterWithName("max_overlap")
                 .optional()
                 .description("If multiple highlights come from the same video, this is the maximum they are allowed to overlap as a % (expressed as a decimal e.g. 0.2 is 20%) of the smallest video. If 1 a highlight can be a full segment of another highlight. If 0 no overlap is allowed.")
-                .attributes(Attributes.key("type").value("String"))
+                .attributes(Attributes.key("type").value("String")),
+
+            RequestDocumentation.parameterWithName("hyper_relevance")
+                .optional()
+                .description("if true, the highlights will start at the part that is most relevant to your query. Default is false, which will return the full duration of the highlights.")
+                .attributes(Attributes.key("type").value("Boolean"))
         )
         RestAssured.given(hestuDocumentationSpec)
             .filter(

--- a/src/test/kotlin/com/boclips/apidocs/HestuDocTests.kt
+++ b/src/test/kotlin/com/boclips/apidocs/HestuDocTests.kt
@@ -178,7 +178,7 @@ class HestuDocTests : AbstractDocTests() {
 
             RequestDocumentation.parameterWithName("hyper_relevance")
                 .optional()
-                .description("if true, the highlights will start at the part that is most relevant to your query. Default is false, which will return the full duration of the highlights.")
+                .description("If true, the highlights will start at the part that is most relevant to your query. Default is false, which will return the full duration of the highlights.")
                 .attributes(Attributes.key("type").value("Boolean"))
         )
         RestAssured.given(hestuDocumentationSpec)


### PR DESCRIPTION
we added a new parameter for the Highlight search endpoint `hyper_relevance` in the api. This is already live on our side and I have also updated the response of the /v1 endpoint